### PR TITLE
Enhance back button functionality for reels/shorts detection

### DIFF
--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,5 +1,5 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accessibilityEventTypes="typeViewClicked|typeViewFocused"
+    android:accessibilityEventTypes="typeViewClicked|typeViewFocused|typeWindowContentChanged|typeWindowStateChanged"
     android:accessibilityFlags="flagDefault"
     android:canRetrieveWindowContent="true"
     android:description="@string/accessibility_service_description"


### PR DESCRIPTION
- Add window content/state change event listeners to detect scrolling
- Implement recursive view hierarchy scanning for reels/shorts indicators
- Check view IDs, text content, and content descriptions across entire screen
- Add app-specific detection for YouTube Shorts, Instagram Reels, and Facebook Reels
- Automatically press back button when user is viewing or scrolling through reels

This ensures the back button is triggered not just on clicks, but also when users are actively viewing and scrolling through addictive short-form content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)